### PR TITLE
user can select a category when creating a product

### DIFF
--- a/website/forms.py
+++ b/website/forms.py
@@ -13,4 +13,4 @@ class ProductForm(forms.ModelForm):
 
   class Meta:
     model = Product
-    fields = ('title', 'description', 'price', 'quantity',)
+    fields = ('title', 'description', 'price', 'quantity', 'product_category')

--- a/website/models.py
+++ b/website/models.py
@@ -40,7 +40,7 @@ class Product(models.Model):
     purpose: Creates Product table within database
         Example useage: 
 
-    author: Taylor Perkins, Justin Short
+    author: Taylor Perkins, Justin Short, Casey Dailey
 
     args: models.Model: (NA): models class given by Django
 
@@ -50,9 +50,18 @@ class Product(models.Model):
         User,
         on_delete=models.CASCADE,
     )
+    #django will display a dropdown with these choices
+    CATEGORY_CHOICES = (
+    ('electronics','ELECTRONICS'),
+    ('sports', 'SPORTS'),
+    ('home','HOME'),
+    ('general','GENERAL'),
+    ('clothing','CLOTHING'),
+    )
     product_category = models.ForeignKey(
         Category,
         on_delete=models.CASCADE,
+        choices=CATEGORY_CHOICES
     )
     quantity = models.IntegerField(null=False)
     description = models.TextField(null=False, max_length=500)

--- a/website/views.py
+++ b/website/views.py
@@ -90,6 +90,15 @@ def user_logout(request):
     return HttpResponseRedirect('/')
 
 def sell_product(request):
+    """
+    purpose: produce a form for the user to create a product to sell
+
+    author: casey dailey
+
+    args: request
+
+    returns: redirect to detail view for product created
+    """
     if request.method == 'GET':
         product_form = ProductForm()
         template_name = 'product/create.html'
@@ -104,10 +113,11 @@ def sell_product(request):
             description = form_data['description'],
             price = form_data['price'],
             quantity = form_data['quantity'],
+            #create an instance of category of where category_name = the user's choice
+            product_category = Category.objects.get(category_name=form_data['product_category'])
         )
         p.save()
-        template_name = 'product/details.html'
-        return render(request, template_name)
+        return HttpResponseRedirect('product_details/{}'.format(p.id))
 
 def list_products(request):
     template_name = 'product/list.html'


### PR DESCRIPTION
# user can select a category when creating a product

## Status
READY

## Description

When creating a product to sell, the user can (and must) select a category type for their product

## Related Tickets 

https://github.com/Trashy-Armadillos/djangazon/issues/10

## Impacted Areas of the Application
 
```
        modified:   website/forms.py
	modified:   website/models.py
	modified:   website/views.py
```
In forms.py, I've added the field 'product_category'
in models.py, I've augmented the class def for Product to include 'CATEGORY_CHOICES'
in views.py, I've changed the sell_product method to include a category instance on the 'p' object that is saved to the db. and changed the return to redirect to the detail view for that product

## Deploy Notes

from djangazon/
 
```
    git pull 
    git fetch --all
    git checkout cjd-category-dropdown
    ./refresh_database.sh
    python manage.py runserver
```

navigate to http://127.0.0.1:8000/ 
and confirm that when a user attempts to add a product 

0) there is a category dropdown on the product form
1) they must select a category (error if not)
2) they are redirected to the appropriate detail view for that product they just created

## Testing
Tests run?
 nope
Are all tests passing?
nope
If not, why?
no tests

## READ_ME updates
Have you updated the README to reflect any relevant changes?
nope
