### PR TITLE
User payment displaying on 'edit payment' view. DOES NOT DELETE YET.

### DIFF
--- a/website/templates/account/edit_payment.html
+++ b/website/templates/account/edit_payment.html
@@ -9,8 +9,9 @@
     <h1>Edit Selected Payment Page</h1>
 
     <ol>
-    {% for product in products %}
-        <li>{{ product.title }}</li>
+    {% for payment_type in payment_types %}
+        <li>{{ payment_type.name }}</li>
+        <li>{{ payment_type.account_number }}</li>
     {% endfor %}
     </ol>
   </body>

--- a/website/views.py
+++ b/website/views.py
@@ -135,7 +135,7 @@ def add_payment_type(request):
     args: name: (string), acount number of credit card
 
     returns: (render): a view of of the request, template to use, and product obj
-    '''
+    ''' 
     if request.method == 'GET':
         add_payment_form = AddPaymentForm()
         template_name = 'account/add_payment.html'
@@ -265,13 +265,13 @@ def edit_account(request):
     template_name = 'account/edit_account.html'
     return render(request, template_name)
 
+# @login_required
 def edit_payment_type(request):
+    payment_types = PaymentType.objects.filter(user=request.user)
     template_name = 'account/edit_payment.html'
-    return render(request, template_name)
-
-# def add_payment_type(request):
-#     template_name = 'account/add_payment.html'
-#     return render(request, template_name)
+    return render(request, template_name, {
+        "payment_types": payment_types
+        })
 
 @login_required
 def view_order(request, order_id):


### PR DESCRIPTION
# Trashy Armadillos Pull Request Template

## Status
Is this PR ready to be looked at by other group members? 
YES

## Description
WHEN USER IS LOGGED IN, AND GOES TO EDIT THEIR PAYMENT TYPE, THE PAYMENT TYPES IN THE DATA BASE DISPLAY FOR THAT USER.

## Related Tickets 

https://github.com/Trashy-Armadillos/djangazon/projects/1#card-2949473

## Impacted Areas of the Application
Files that this PR modifies or affects in some way. 
```
    views.py
    edit_payment.html

```

## Deploy Notes
WHEN USER IS ON HOME PAGE, AND IS LOGGED IN, THEY CLICK ON 'ACCOUNT' LINK AND THEN ON 'EDIT ACCOUNT' LINK AND IT WILL TAKE THEM TO A VIEW THAT HAS A 'EDIT PAYMENT' LINK, THE VIEW SHOULD DISPLAY ALL PAYMENT TYPES ASSOCIATED WITH THAT USERS ACCOUNT. THEY ARE NOT ABLE TO DELETE PAYMENT TYPES YET.
For example: 
```
    git pull 
    git fetch --all
    git checkout mr-delete-payment-type
    python manage.py makemigration
    python manage.py migrate
    python manage.py runserver
```

## Testing
Tests run? NO
Are all tests passing? NO
If not, why? NO

## READ_ME updates
Have you updated the README to reflect any relevant changes?
