### PR TITLE
fixed the duplication bug in search

### DIFF
--- a/website/templates/product/list.html
+++ b/website/templates/product/list.html
@@ -13,22 +13,10 @@
 
     <ol>
 
-    {% for product in products %} 
+    {% for product in results %} 
         <li><a href="{% url 'website:product_details' product.id %}">{{ product.title }}</a></li>
     {% endfor %} 
-
-    {% for product in city_contains %} 
-        <li><a href="{% url 'website:product_details' product.id %}">{{ product.title }}</a></li>
-    {% endfor %} 
-
-    {% for product in title_contains %}
-        <li><a href="{% url 'website:product_details' product.id %}">{{ product.title }}</a></li>
-    {% endfor %}
-
-    {% for product in description_contains %}
-        <li><a href="{% url 'website:product_details' product.id %}">{{ product.title }}</a></li>
-    {% endfor %}
-
+    
     </ol>
   </body>
 </html>

--- a/website/views/list_products.py
+++ b/website/views/list_products.py
@@ -15,28 +15,24 @@ def list_products(request):
     if request.method == 'GET':
         # get value of search_box
         search_query = request.GET.get('search_box')
-
+        print("search: {}".format(search_query))
         # if they're searching and search_query is truthy (meaning it's not blank), 
         # filter products where title, description, or city contains search_query
         if 'search_box' in request.GET and search_query:
-            title_contains = Product.objects.filter(title__contains=search_query)
-            description_contains = Product.objects.filter(description__contains=search_query)
-            city_contains = Product.objects.filter(city__contains=search_query)
+            results = set()
+            results.update(Product.objects.filter(title__contains=search_query))
+            results.update(Product.objects.filter(description__contains=search_query))
+            results.update(Product.objects.filter(city__contains=search_query))
 
             # if any return match, display
-            if title_contains or description_contains or city_contains:
-                template_name = 'product/list.html'
-                return render(request, template_name, {
-                    "title_contains": title_contains, 
-                    "description_contains": description_contains,
-                    "city_contains": city_contains})
+            if results:
+                return render(request, 'product/list.html', {"results": results})
 
             # no results 
             else:
-                template_name = 'product/no_products.html'
-                return render(request, template_name)
+                return render(request, 'product/no_products.html')
 
-    # they searched for nothing    
-    else:
-        template_name = 'product/no_products.html'
-        return render(request, template_name)
+        # they searched for nothing    
+        else:
+            return render(request, 'product/no_products.html')
+            


### PR DESCRIPTION
# fixed the duplication bug in search

## Status

READY

## Description

eliminated the problem of duplicate returns in the search and list feature

## Related Tickets 

#4 

#5 


## Impacted Areas of the Application
Files that this PR modifies or affects in some way. 
```
       modified:   website/templates/product/list.html
	modified:   website/views/list_products.py
```

## Deploy Notes

```
    git pull 
    git fetch --all
    git checkoutcjd-refine-search
    ./refresh_database.sh
    python manage.py runserver
```
previously, when you input something like  "s" in the search, it would return 66 products
basically, every time there was an "s" in product description or city

this shouldn't  happen anymore

## Testing
Tests run? yes
Are all tests passing? yes
If not, why?

## READ_ME updates
Have you updated the README to reflect any relevant changes?
NOPE